### PR TITLE
Replace empty lines with spaces

### DIFF
--- a/app/src/main/java/com/cg/lrceditor/FinalizeActivity.java
+++ b/app/src/main/java/com/cg/lrceditor/FinalizeActivity.java
@@ -360,6 +360,9 @@ public class FinalizeActivity extends AppCompatActivity {
             String timestamp = lyricData.get(i).getTimestamp();
             if (timestamp != null) {
                 String lyric = lyricData.get(i).getLyric();
+                if (lyric == null || lyric.equals("")) {
+                    lyric = " ";
+                }
                 sb.append("[").append(timestamp).append("]").append(lyric).append("\n");
             }
         }


### PR DESCRIPTION
Some music players (like the Huawei stock music player) ignore timestamps followed directly by newline characters. Add spaces to make these visible.