### PR TITLE
Fix crash when exiting SupportActivity if billing is unavailable

### DIFF
--- a/app/src/main/java/com/cg/lrceditor/IAP/IabHelper.java
+++ b/app/src/main/java/com/cg/lrceditor/IAP/IabHelper.java
@@ -329,7 +329,12 @@ public class IabHelper {
         mSetupDone = false;
         if (mServiceConn != null) {
             logDebug("Unbinding from service.");
-            if (mContext != null) mContext.unbindService(mServiceConn);
+            if (mContext != null) {
+                try {
+                    mContext.unbindService(mServiceConn);
+                } catch (IllegalArgumentException ignored) {}
+                /* Thrown if billing is unavailable and was never registered */
+            }
         }
         mDisposed = true;
         mContext = null;


### PR DESCRIPTION
You can't unbind what was never bound.