### PR TITLE
Save existing file in its location

### DIFF
--- a/app/src/main/java/com/cg/lrceditor/EditorActivity.java
+++ b/app/src/main/java/com/cg/lrceditor/EditorActivity.java
@@ -70,6 +70,7 @@ public class EditorActivity extends AppCompatActivity implements LyricListAdapte
 	private boolean isDarkTheme = false;
 
 	private String lrcFileName = null;
+	private String lrcFilePath = null; //[JM] Adds lrcFilePath variable to store it from intent entering the activity
 	private Uri songUri = null;
 	private String songFileName = null;
 
@@ -278,6 +279,7 @@ public class EditorActivity extends AppCompatActivity implements LyricListAdapte
 
 			metadata = (Metadata) intent.getSerializableExtra(IntentSharedStrings.METADATA);
 			lrcFileName = intent.getStringExtra(IntentSharedStrings.LRC_FILE_NAME);
+			lrcFilePath = intent.getStringExtra(IntentSharedStrings.LRC_FILE_PATH); //[JM] Gets path from IntentExtra
 
 			adapter = new LyricListAdapter(this, lyricData, isDarkTheme);
 			adapter.setClickListener(this);
@@ -1487,6 +1489,7 @@ public class EditorActivity extends AppCompatActivity implements LyricListAdapte
 					intent.putExtra(IntentSharedStrings.METADATA, metadata);
 					intent.putExtra(IntentSharedStrings.SONG_FILE_NAME, songFileName);
 					intent.putExtra(IntentSharedStrings.LRC_FILE_NAME, lrcFileName);
+					intent.putExtra(IntentSharedStrings.LRC_FILE_PATH, lrcFilePath); //[JM] Passes the lrcFilePath variable to next Activity through intent
 
 					startActivity(intent);
 				}

--- a/app/src/main/java/com/cg/lrceditor/FileUtil.java
+++ b/app/src/main/java/com/cg/lrceditor/FileUtil.java
@@ -228,4 +228,14 @@ public final class FileUtil {
 
 		return f.findFile(name);
 	}
+
+	@Nullable
+	static Uri getFileTreeUriFromPath(@Nullable final Uri treeUri, String path, Context ctx) {
+		if (treeUri == null || !treeUri.toString().contains("content://com.android.externalstorage.documents/tree/")) return null;
+		String treePath = getFullPathFromTreeUri(treeUri, ctx);
+		if(!path.contains(treePath)) return  null;
+
+		String encodedRelativePath = Uri.encode(path.substring(treePath.length()));
+		return Uri.parse(treeUri.toString()+encodedRelativePath);
+	}
 }

--- a/app/src/main/java/com/cg/lrceditor/FileUtil.java
+++ b/app/src/main/java/com/cg/lrceditor/FileUtil.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.List;
 
 public final class FileUtil {
 	private static final String PRIMARY_VOLUME_NAME = "primary";
@@ -236,6 +237,28 @@ public final class FileUtil {
 		if(!path.contains(treePath)) return  null;
 
 		String encodedRelativePath = Uri.encode(path.substring(treePath.length()));
-		return Uri.parse(treeUri.toString()+encodedRelativePath);
+		//return Uri.parse(treeUri.toString()+encodedRelativePath);
+		return Uri.withAppendedPath(treeUri, encodedRelativePath);
+	}
+
+	@Nullable
+	static  DocumentFile getDocumentFileFromPath(@Nullable final Uri treeUri, String path, Context ctx){
+		if (treeUri == null || !treeUri.toString().contains("content://com.android.externalstorage.documents/tree/")) return null;
+		String treePath = getFullPathFromTreeUri(treeUri, ctx);
+		if(!path.contains(treePath)) return  null;
+
+		String relativePath = Uri.encode(path.substring(treePath.length()));
+
+		//Uri fileUri = getFileTreeUriFromPath(treeUri, path, ctx);
+		Uri fileUri = Uri.parse(Uri.decode(relativePath));
+		DocumentFile file = DocumentFile.fromTreeUri(ctx, treeUri);
+
+		List<String> pathSegments = fileUri.getPathSegments();
+
+		for (String pathSegment:pathSegments) {
+			file = file.findFile(pathSegment);
+		}
+
+		return file;
 	}
 }

--- a/app/src/main/java/com/cg/lrceditor/HomePage.java
+++ b/app/src/main/java/com/cg/lrceditor/HomePage.java
@@ -542,6 +542,7 @@ public class HomePage extends AppCompatActivity implements HomePageListAdapter.L
 					intent.putExtra(IntentSharedStrings.LYRIC_DATA, r.getLyricData());
 					intent.putExtra(IntentSharedStrings.METADATA, r.getMetadata());
 					intent.putExtra(IntentSharedStrings.LRC_FILE_NAME, fileName);
+					intent.putExtra(IntentSharedStrings.LRC_FILE_PATH, fileLocation); //[JM] Adds the file path to intent to pass it to the next Activity
 
 					startActivity(intent);
 				});

--- a/app/src/main/java/com/cg/lrceditor/IntentSharedStrings.java
+++ b/app/src/main/java/com/cg/lrceditor/IntentSharedStrings.java
@@ -6,5 +6,6 @@ class IntentSharedStrings {
 	static final String SONG_URI = "SONG URI";
 	static final String METADATA = "METADATA";
 	static final String LRC_FILE_NAME = "LRC_FILE_NAME";
+	static final String LRC_FILE_PATH = "LRC_FILE_PATH"; //[JM] To pass the path in the intent extras
 	static final String SONG_FILE_NAME = "SONG_FILE_NAME";
 }

--- a/app/src/main/res/layout/dialog_save_lrc.xml
+++ b/app/src/main/res/layout/dialog_save_lrc.xml
@@ -76,7 +76,7 @@
 				android:layout_width="0dp"
 				android:layout_height="wrap_content"
 				android:layout_weight=".3"
-				android:onClick="editSaveLocation"
+				android:onClick="changeSaveLocation"
 				android:text="@string/change" />
 
 		</LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -93,7 +93,7 @@
 	<string name="no_permission_to_write_text">Konnte die Berechtigung zum Beschreiben nicht erhalten</string>
 	<string name="no_timestamp_set_message">Für diese Zeile existiert kein Zeitstempel</string>
 	<string name="ok">OK</string>
-	<string name="overwrite_prompt">Die Datei \"%1$s.lrc\" existiert bereits unter %2$s. Möchtest du sie überschreiben?</string>
+	<string name="overwrite_prompt">Die Datei \"%1$s\" existiert bereits unter %2$s. Möchtest du sie überschreiben?</string>
 	<string name="paste_lyrics_prompt">Gib/Füge die Lyrics hier ein:</string>
 	<string name="permission_check_message">Bitte stelle sicher, dass du der App alle nötigen Berechtigungen erteilt hast</string>
 	<string name="play_button_description">Knopf, um die Musik zu pausieren/fortsetzen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -93,7 +93,7 @@
 	<string name="no_permission_to_write_text">No se ha podido conseguir permiso de escritura</string>
 	<string name="no_timestamp_set_message">Ningún indicador de tiempo para este verso</string>
 	<string name="ok">OK</string>
-	<string name="overwrite_prompt">El archivo \"%1$s.lrc\" ya existe. ¿Quiere sobrescribirlo?</string>
+	<string name="overwrite_prompt">El archivo \"%1$s\" ya existe. ¿Quiere sobrescribirlo?</string>
 	<string name="paste_lyrics_prompt">Pegar la letra debajo :</string>
 	<string name="permission_check_message">Por favor verificar que se le han dado los permisos necesarios al buen funcionamiento de la aplicación.</string>
 	<string name="play_button_description">Botón de reproducción\/pausa</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -93,7 +93,7 @@
 	<string name="no_permission_to_write_text">No se ha podido conseguir permiso de escritura</string>
 	<string name="no_timestamp_set_message">Ningún indicador de tiempo para este verso</string>
 	<string name="ok">OK</string>
-	<string name="overwrite_prompt">El archivo \"%1$s\" ya existe. ¿Quiere sobrescribirlo?</string>
+	<string name="overwrite_prompt">El archivo \"%1$s\" ya existe en la carperta %2$s. ¿Quiere sobrescribirlo?</string>
 	<string name="paste_lyrics_prompt">Pegar la letra debajo :</string>
 	<string name="permission_check_message">Por favor verificar que se le han dado los permisos necesarios al buen funcionamiento de la aplicación.</string>
 	<string name="play_button_description">Botón de reproducción\/pausa</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -93,7 +93,7 @@
 	<string name="no_permission_to_write_text">Impossible de sauvegarder sans la permission sous-jacente</string>
 	<string name="no_timestamp_set_message">Aucun marqueur temporel pour ce vers</string>
 	<string name="ok">OK</string>
-	<string name="overwrite_prompt">Le fichier \"%1$s.lrc\" existe déjà dans le répertoire %2$s. Êtes-vous sûr de vouloir l\'écraser ?</string>
+	<string name="overwrite_prompt">Le fichier \"%1$s\" existe déjà dans le répertoire %2$s. Êtes-vous sûr de vouloir l\'écraser ?</string>
 	<string name="paste_lyrics_prompt">Coller les paroles en dessous :</string>
 	<string name="permission_check_message">Merci de vérifier que vous avez bien accordé les permissions nécessaires au bon fonctionnement de l\'appli.</string>
 	<string name="play_button_description">Bouton pour lancer ou mettre en pause la lecture</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -93,7 +93,7 @@
 	<string name="no_permission_to_write_text">Impossible de sauvegarder sans la permission sous-jacente</string>
 	<string name="no_timestamp_set_message">Aucun marqueur temporel pour ce vers</string>
 	<string name="ok">OK</string>
-	<string name="overwrite_prompt">Le fichier \"%1$s.lrc\" existe déjà. Êtes-vous sûr de vouloir l\'écraser ?</string>
+	<string name="overwrite_prompt">Le fichier \"%1$s.lrc\" existe déjà dans le répertoire %2$s. Êtes-vous sûr de vouloir l\'écraser ?</string>
 	<string name="paste_lyrics_prompt">Coller les paroles en dessous :</string>
 	<string name="permission_check_message">Merci de vérifier que vous avez bien accordé les permissions nécessaires au bon fonctionnement de l\'appli.</string>
 	<string name="play_button_description">Bouton pour lancer ou mettre en pause la lecture</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -93,7 +93,7 @@
 	<string name="no_permission_to_write_text">Tidak dapat izin untuk menulis</string>
 	<string name="no_timestamp_set_message">Item lirik tersebut tak mempunyai cap waktu</string>
 	<string name="ok">OK</string>
-	<string name="overwrite_prompt">Berkas \'%1$s.lrc\' sudah ada di %2$s. Timpa?</string>
+	<string name="overwrite_prompt">Berkas \'%1$s\' sudah ada di %2$s. Timpa?</string>
 	<string name="paste_lyrics_prompt">Tempelkan lirik tersebut ke bawah</string>
 	<string name="permission_check_message">Pastikan izin sudah diberikan</string>
 	<string name="play_button_description">Tombol untuk memutar/menjeda media</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -93,7 +93,7 @@
 	<string name="no_permission_to_write_text">Nie można uzyskać uprawnień do zapisu</string>
 	<string name="no_timestamp_set_message">Nie ustawiono znacznika czasu dla elementu</string>
 	<string name="ok">OK</string>
-	<string name="overwrite_prompt">"Plik '%1$s.lrc' już istnieje w %2$s. Czy na pewno chcesz go zastąpić?"</string>
+	<string name="overwrite_prompt">"Plik '%1$s' już istnieje w %2$s. Czy na pewno chcesz go zastąpić?"</string>
 	<string name="paste_lyrics_prompt">Wklej tekst poniżej</string>
 	<string name="permission_check_message">Upewnij się, że udzieliłeś uprawnień</string>
 	<string name="play_button_description">Przycisk odtwórz/zatrzymaj</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -93,7 +93,7 @@
 	<string name="no_permission_to_write_text">Não foi possível obter permissões para criar/modificar arquivos</string>
 	<string name="no_timestamp_set_message">Nenhum tempo definido para o item da letra</string>
 	<string name="ok">OK</string>
-	<string name="overwrite_prompt">O arquivo \'%1$s.lrc\' já existe em %2$s. Tem certeza de que deseja sobrescrevê-lo??</string>
+	<string name="overwrite_prompt">O arquivo \'%1$s\' já existe em %2$s. Tem certeza de que deseja sobrescrevê-lo??</string>
 	<string name="paste_lyrics_prompt">Cole as letras abaixo</string>
 	<string name="permission_check_message">Certifique-se de ter concedido permissões</string>
 	<string name="play_button_description">Botão para reproduzir/pausar mídia</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -94,7 +94,7 @@
 	<string name="no_permission_to_write_text">无法取得写入权限</string>
 	<string name="no_timestamp_set_message">没有为歌词物件设置时间标记组</string>
 	<string name="ok">确定</string>
-	<string name="overwrite_prompt">%2$s 文件夹中具有相同名称的文件 \'%1$s.lrc\' 已经存在。您想要取代此文件吗？</string>
+	<string name="overwrite_prompt">%2$s 文件夹中具有相同名称的文件 \'%1$s\' 已经存在。您想要取代此文件吗？</string>
 	<string name="paste_lyrics_prompt">在下面粘贴歌词</string>
 	<string name="permission_check_message">请确定您已授予权限</string>
 	<string name="play_button_description">播放/暂停</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -93,7 +93,7 @@
 	<string name="no_permission_to_write_text">無法取得寫入權限</string>
 	<string name="no_timestamp_set_message">沒有為歌詞物件設定時間標記組</string>
 	<string name="ok">確定</string>
-	<string name="overwrite_prompt">資料夾 %2$s 中具有相同名稱的檔案 \'%1$s.lrc\' 已經存在。您想要取代此檔案嗎？</string>
+	<string name="overwrite_prompt">資料夾 %2$s 中具有相同名稱的檔案 \'%1$s\' 已經存在。您想要取代此檔案嗎？</string>
 	<string name="paste_lyrics_prompt">在下面貼上歌詞</string>
 	<string name="permission_check_message">請確定您已授予權限</string>
 	<string name="play_button_description">播放/暫停</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,7 +93,7 @@
 	<string name="no_permission_to_write_text">Could not obtain permissions to write</string>
 	<string name="no_timestamp_set_message">No timestamp set for the lyric item</string>
 	<string name="ok">OK</string>
-	<string name="overwrite_prompt">File \'%1$s.lrc\' already exists in %2$s. Are you sure you want to overwrite it?</string>
+	<string name="overwrite_prompt">File \'%1$s\' already exists in %2$s. Are you sure you want to overwrite it?</string>
 	<string name="paste_lyrics_prompt">Paste the lyrics below</string>
 	<string name="permission_check_message">Make sure you have granted permissions</string>
 	<string name="play_button_description">Button to play/pause media</string>


### PR DESCRIPTION
Hey there Jas!

I made it. The functionality to overwrite the edited file by default now works. You can also select a save path without changing the default in settings.
Probably the "Location for saving lyric files" in the settings wouldn't be required any more, but I kept it there, for the ability to use as a default path to save new files that could be different from the read location.

My commit message is succinct, but the code is commented to explain the modifications. Along with diff tool you should be able to pick up what I did.

Let me know!
Jonathan