### PR TITLE
Fixes edit_button width to dp84 so French and Spanish text fits

### DIFF
--- a/app/src/main/res/layout/row_lyricfile_item.xml
+++ b/app/src/main/res/layout/row_lyricfile_item.xml
@@ -60,7 +60,7 @@
 
 		<Button
 			android:id="@+id/edit_button"
-			android:layout_width="@dimen/dp60"
+			android:layout_width="@dimen/dp84"
 			android:layout_height="wrap_content"
 			android:layout_alignParentEnd="true"
 			android:layout_centerVertical="true"


### PR DESCRIPTION
Hey Jas,

A small fix so the Spanish and French edit button text fits. Just changed the button width to dp84.

Jonathan